### PR TITLE
Fix null-termination of strings

### DIFF
--- a/minibson.hpp
+++ b/minibson.hpp
@@ -141,9 +141,10 @@ namespace minibson {
             };
 
             void serialize(void* const buffer, const size_t count) const {
-                *reinterpret_cast<unsigned int*>(buffer) = value.length() + 1;
-                std::memcpy(reinterpret_cast<char*>(buffer) + sizeof(unsigned int), value.c_str(), value.length());
-                *(reinterpret_cast<char*>(buffer) + count - 1) = '\0';
+		size_t strLen = value.length();
+                *reinterpret_cast<unsigned int*>(buffer) = strLen + 1;
+                std::memcpy(reinterpret_cast<char*>(buffer) + sizeof(unsigned int), value.c_str(), strLen);
+                *(reinterpret_cast<char*>(buffer) + sizeof(unsigned int) + strLen) = '\0';
             }
 
             size_t get_serialized_size() const {


### PR DESCRIPTION
Strings were not being serialized correctly.  The NULL character was being written at a random offset (as it was using the count parameter as an index, not the length of the string)