### PR TITLE
FIx string fields parsing in microbson

### DIFF
--- a/microbson.hpp
+++ b/microbson.hpp
@@ -89,12 +89,12 @@ namespace microbson
                 case document_node:
                     result += *reinterpret_cast<int*>(bytes + result);
                     break;
-                case string_node:
                 case binary_node:
+                    result += 1U;
+                case string_node:
                     result += (
                         sizeof(int) 
                             + *reinterpret_cast<int*>(bytes + result)
-                            + 1U
                     );
                     break;
                 case boolean_node:


### PR DESCRIPTION
String fields don't need the extra byte at the end